### PR TITLE
Don't redefine Parser#on_parser_error to avoid method redefinition warning

### DIFF
--- a/lib/pry-inline/parser.rb
+++ b/lib/pry-inline/parser.rb
@@ -10,6 +10,8 @@ module PryInline
     end
 
     Ripper::PARSER_EVENTS.each do |event|
+      next if event == :parse_error # A custom handler is provided below
+
       module_eval(<<-End, __FILE__, __LINE__ + 1)
         def on_#{event}(*args)
           args.unshift :#{event}


### PR DESCRIPTION
Fixes #5 