### PR TITLE
Use source_location rather than eval('__LINE__')

### DIFF
--- a/lib/pry-inline/code_extension.rb
+++ b/lib/pry-inline/code_extension.rb
@@ -17,7 +17,12 @@ module PryInline
         @lineno_to_variables = Hash.new { |h, k| h[k] = Set.new }
         traverse_sexp(Parser.sexp(@lines.map(&:line).join("\n")))
 
-        current_line = CodeExtension.current_binding.eval('__LINE__') - @lines[0].lineno + 1
+        current_line =
+          if CodeExtension.current_binding.respond_to?(:source_location)
+            CodeExtension.current_binding.source_location[1]
+          else
+            CodeExtension.current_binding.eval('__LINE__')
+          end - @lines[0].lineno + 1
         @lineno_to_variables.each do |lineno, variables|
           if lineno >= current_line
             variables.clear


### PR DESCRIPTION
Under Ruby 2.7, pry-inline is generating a warning:
```ruby
warning: __LINE__ in eval may not return location in binding; use Binding#source_location instead
gems/pry-inline/lib/pry-inline/code_extension.rb:20: warning: in `eval'
```
this is related to the line:
```ruby
CodeExtension.current_binding.eval('__LINE__')
```

This change checks whether the user is running a version of ruby that supports `Binding#source_location` and uses that instead if it is available.
